### PR TITLE
Gulp Modernizr task in sequence + scss-lint turned off

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,7 +60,8 @@ var gulp           = require('gulp'),
 	scsslint       = require('gulp-scss-lint'),
 	gulpif         = require('gulp-if'),
 	argv           = require('yargs').argv,
-	sh             = require('execSync');
+	sh             = require('execSync'),
+	runSequence    = require('run-sequence');
 
 var semver;
 var paths = {};
@@ -152,7 +153,7 @@ gulp.task('browser-sync', ['sass-ie', 'sass-cms', 'sass', 'javascript'], functio
 	});
 });
 
-gulp.task('sass', ['scss-lint'], function () {
+gulp.task('sass', ['scss-lint'], function() {
 
 	var pxtoremOptions = {
 		root_value: 10,
@@ -256,7 +257,7 @@ gulp.task('bower-concat', function() {
 	;
 });
 
-gulp.task('jshint', function () {
+gulp.task('jshint', function() {
 	return gulp.src(paths.jsSrc + '/**/*.js')
 		.pipe(jshint('.jshintrc'))
 		.pipe(jshint.reporter('jshint-stylish'));
@@ -270,7 +271,7 @@ gulp.task('modernizr', ['sass', 'javascript'], function() {
 	;
 });
 
-gulp.task('images', ['init'], function () {
+gulp.task('images', ['init'], function() {
 	if (argv.skipImages) {
 		return;
 	}
@@ -285,7 +286,8 @@ gulp.task('images', ['init'], function () {
 	;
 });
 
-gulp.task('watch', ['default', 'browser-sync'], function() {
+gulp.task('watch', function(cb) {
+	runSequence('default', 'browser-sync', cb);
 	gulp.watch([paths.cssSrc + '/**/*.scss', '!**/cms.scss'], ['sass']);
 	gulp.watch(paths.cssSrc + '/**/cms.scss', ['sass-cms']);
 	gulp.watch(paths.jsSrc + '/**/*.js', ['javascript']);
@@ -304,7 +306,6 @@ gulp.task('build', [
 	'images'
 ]);
 
-gulp.task('default', [
-	'build',
-	'modernizr'
-]);
+gulp.task('default', function(cb) {
+	runSequence('build', 'modernizr', cb);
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,10 +46,10 @@ var gulp           = require('gulp'),
 	gutil          = require('gulp-util'),
 	concat         = require('gulp-concat'),
 	jshint         = require('gulp-jshint'),
-    jshintStylish  = require('jshint-stylish'),
-    imagemin       = require('gulp-imagemin'),
-    minifycss      = require('gulp-minify-css'),
-    urlAdjuster    = require('gulp-css-url-adjuster'),
+	jshintStylish  = require('jshint-stylish'),
+	imagemin       = require('gulp-imagemin'),
+	minifycss      = require('gulp-minify-css'),
+	urlAdjuster    = require('gulp-css-url-adjuster'),
 	pxtorem        = require('gulp-pxtorem'),
 	modernizr      = require('gulp-modernizr'),
 	sass           = require('gulp-sass'),
@@ -68,12 +68,12 @@ var ENV = argv.e ? argv.e : 'development';
 
 function getShellOutput(command) {
 	result = sh.exec(command);
-    if (result.stderr) {
+	if (result.stderr) {
 		handleError('Error getting shell output: ' + result.stderr);
-        gutil.beep();
-    }
-    // Do a replace because of newline in shell output
-    return result.stdout.replace(/\s?$/, '');
+		gutil.beep();
+	}
+	// Do a replace because of newline in shell output
+	return result.stdout.replace(/\s?$/, '');
 };
 
 function getConfigValue(value) {
@@ -133,7 +133,7 @@ gulp.task('browser-sync', ['sass-ie', 'sass-cms', 'sass', 'javascript'], functio
 		proxy: domain,
 		open: false,
 		notify: {
-		     styles: [
+			 styles: [
 				"display: none",
 				"padding: 15px",
 				"font-family: sans-serif",
@@ -147,8 +147,8 @@ gulp.task('browser-sync', ['sass-ie', 'sass-cms', 'sass', 'javascript'], functio
 				"margin: 0",
 				"color: white",
 				"text-align: center"
-	        ]
-	    }
+			]
+		}
 	});
 });
 
@@ -168,8 +168,8 @@ gulp.task('sass', ['scss-lint'], function () {
 		map: true
 	};
 
-    gutil.log(gutil.colors.green('Building css to ' + paths.cssBuild));
-    return gulp.src([paths.cssSrc + '/base.scss'])
+	gutil.log(gutil.colors.green('Building css to ' + paths.cssBuild));
+	return gulp.src([paths.cssSrc + '/base.scss'])
 		.pipe(sass({
 			onError: browserSync.notify
 		})).on('error', handleError)
@@ -181,13 +181,13 @@ gulp.task('sass', ['scss-lint'], function () {
 			append: '?v=' + semver
 		})))
 		.pipe(gulpif(ENV != 'development', minifycss()))
-        .pipe(gulp.dest(paths.cssBuild))
+		.pipe(gulp.dest(paths.cssBuild))
 		.pipe(browserSync.reload({stream:true}))
 	;
 });
 
 gulp.task('sass-cms', function() {
-    return gulp.src(paths.cssSrc + '/cms.scss')
+	return gulp.src(paths.cssSrc + '/cms.scss')
 		.pipe(sass()).on('error', handleError)
 		.pipe(gulpif(ENV != 'development', minifycss()))
 		.pipe(gulp.dest(paths.cssBuild))
@@ -195,7 +195,7 @@ gulp.task('sass-cms', function() {
 });
 
 gulp.task('sass-ie', function() {
-    return gulp.src(paths.cssSrc + '/ie-old.scss')
+	return gulp.src(paths.cssSrc + '/ie-old.scss')
 		.pipe(sass()).on('error', handleError)
 		.pipe(gulpif(ENV != 'development', minifycss()))
 		.pipe(gulp.dest(paths.cssBuild))
@@ -209,8 +209,8 @@ gulp.task('scss-lint', function() {
 });
 
 gulp.task('javascript', ['jshint', 'bower-concat'], function() {
-    gutil.log(gutil.colors.green('Building js to ' + paths.jsBuild));
-    return gulp.src([
+	gutil.log(gutil.colors.green('Building js to ' + paths.jsBuild));
+	return gulp.src([
 		paths.jsSrc + '/../garp/front/styling.js',
 		paths.jsSrc + '/../garp/front/flashmessage.js',
 		paths.jsSrc + '/../garp/front/cookies.js',
@@ -222,26 +222,26 @@ gulp.task('javascript', ['jshint', 'bower-concat'], function() {
 		.pipe(gulpif(ENV == 'development', sourcemaps.write()))
 		.pipe(gulp.dest(paths.jsBuild))
 		.pipe(browserSync.reload({stream:true}))
-    ;
+	;
 });
 
 gulp.task('javascript-cms', function() {
-    return gulp.src(require('./garp/public/js/cmsBuildStack.js').stack)
+	return gulp.src(require('./garp/public/js/cmsBuildStack.js').stack)
 		.pipe(concat('cms.js'))
 		.pipe(gulpif(ENV != 'development', uglify())).on('error', handleError)
 		.pipe(gulp.dest(paths.jsBuild))
-    ;
+	;
 });
 
 gulp.task('javascript-models', function() {
-    return gulp.src([
+	return gulp.src([
 		paths.jsSrc + '/../garp/models/*.js',
 		paths.jsSrc + '/../models/*.js',
 	])
 		.pipe(concat('extended-models.js'))
 		.pipe(uglify()).on('error', handleError)
 		.pipe(gulp.dest(paths.jsBuild))
-    ;
+	;
 });
 
 gulp.task('bower-concat', function() {
@@ -249,17 +249,17 @@ gulp.task('bower-concat', function() {
 		gutil.log('No bower dependencies');
 		return;
 	}
-    return gulp.src(mainBowerFiles())
-	    .pipe(concat('libs.js'))
-	    .pipe(uglify())
-	    .pipe(gulp.dest(paths.jsBuild))
+	return gulp.src(mainBowerFiles())
+		.pipe(concat('libs.js'))
+		.pipe(uglify())
+		.pipe(gulp.dest(paths.jsBuild))
 	;
 });
 
 gulp.task('jshint', function () {
-    return gulp.src(paths.jsSrc + '/**/*.js')
-        .pipe(jshint('.jshintrc'))
-        .pipe(jshint.reporter('jshint-stylish'));
+	return gulp.src(paths.jsSrc + '/**/*.js')
+		.pipe(jshint('.jshintrc'))
+		.pipe(jshint.reporter('jshint-stylish'));
 });
 
 gulp.task('modernizr', ['sass', 'javascript'], function() {
@@ -267,7 +267,7 @@ gulp.task('modernizr', ['sass', 'javascript'], function() {
 		.pipe(modernizr('modernizr.js')).on('error', handleError)
 		.pipe(uglify())
 		.pipe(gulp.dest(paths.jsBuild))
-    ;
+	;
 });
 
 gulp.task('images', ['init'], function () {
@@ -275,14 +275,14 @@ gulp.task('images', ['init'], function () {
 		return;
 	}
 	gutil.log(gutil.colors.green('Building images to ' + paths.imgBuild));
-    return gulp.src(paths.imgSrc + '/*.{png,gif,jpg,svg}')
-        .pipe(imagemin({
-            progressive: true,
-            svgoPlugins: [{removeViewBox: false}]
-        }))
-        .on('error', handleError)
-        .pipe(gulp.dest(paths.imgBuild))
-    ;
+	return gulp.src(paths.imgSrc + '/*.{png,gif,jpg,svg}')
+		.pipe(imagemin({
+			progressive: true,
+			svgoPlugins: [{removeViewBox: false}]
+		}))
+		.on('error', handleError)
+		.pipe(gulp.dest(paths.imgBuild))
+	;
 });
 
 gulp.task('watch', ['default', 'browser-sync'], function() {
@@ -290,7 +290,7 @@ gulp.task('watch', ['default', 'browser-sync'], function() {
 	gulp.watch(paths.cssSrc + '/**/cms.scss', ['sass-cms']);
 	gulp.watch(paths.jsSrc + '/**/*.js', ['javascript']);
 	gulp.watch(paths.imgSrc + '/**/*.{gif,jpg,svg,png}', ['images']);
-    gulp.watch('application/modules/default/**/*.{phtml, php}', browserSync.reload);
+	gulp.watch('application/modules/default/**/*.{phtml, php}', browserSync.reload);
 });
 
 gulp.task('build', [

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -300,6 +300,7 @@ gulp.task('build', [
 	'sass-ie',
 	'sass-cms',
 	'sass',
+	'scss-lint',
 	'javascript-cms',
 	'javascript-models',
 	'javascript',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,7 +126,7 @@ gulp.task('init', function() {
 	gutil.log(gutil.colors.green('-----------------'));
 });
 
-gulp.task('browser-sync', ['sass-ie', 'sass-cms', 'sass', 'javascript'], function() {
+gulp.task('browser-sync', function() {
 	if (!domain) {
 		handleError('Could not get ' + ENV + ' domain from application/configs/app.ini');
 	}
@@ -153,8 +153,8 @@ gulp.task('browser-sync', ['sass-ie', 'sass-cms', 'sass', 'javascript'], functio
 	});
 });
 
-gulp.task('sass', ['scss-lint'], function() {
-
+// gulp.task('sass', ['scss-lint'], function() {
+gulp.task('sass', function() {
 	var pxtoremOptions = {
 		root_value: 10,
 		unit_precision: 5,
@@ -263,7 +263,7 @@ gulp.task('jshint', function() {
 		.pipe(jshint.reporter('jshint-stylish'));
 });
 
-gulp.task('modernizr', ['sass', 'javascript'], function() {
+gulp.task('modernizr', function() {
 	return gulp.src([paths.cssBuild + '/base.css', paths.jsBuild + '/main.js'])
 		.pipe(modernizr('modernizr.js')).on('error', handleError)
 		.pipe(uglify())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -183,35 +183,39 @@ gulp.task('sass', ['scss-lint'], function () {
 		.pipe(gulpif(ENV != 'development', minifycss()))
         .pipe(gulp.dest(paths.cssBuild))
 		.pipe(browserSync.reload({stream:true}))
+	;
 });
 
 gulp.task('sass-cms', function() {
     return gulp.src(paths.cssSrc + '/cms.scss')
 		.pipe(sass()).on('error', handleError)
 		.pipe(gulpif(ENV != 'development', minifycss()))
-		.pipe(gulp.dest(paths.cssBuild));
+		.pipe(gulp.dest(paths.cssBuild))
+	;
 });
 
 gulp.task('sass-ie', function() {
     return gulp.src(paths.cssSrc + '/ie-old.scss')
 		.pipe(sass()).on('error', handleError)
 		.pipe(gulpif(ENV != 'development', minifycss()))
-		.pipe(gulp.dest(paths.cssBuild));
+		.pipe(gulp.dest(paths.cssBuild))
+	;
 });
 
 gulp.task('scss-lint', function() {
-	gulp.src(paths.cssSrc + '/**/*.scss')
-		.pipe(scsslint({'config': __dirname + '/.scss-lint.yml'})).on('error', handleError);
+	return gulp.src(paths.cssSrc + '/**/*.scss')
+		.pipe(scsslint({'config': __dirname + '/.scss-lint.yml'})).on('error', handleError)
+	;
 });
 
 gulp.task('javascript', ['jshint', 'bower-concat'], function() {
     gutil.log(gutil.colors.green('Building js to ' + paths.jsBuild));
     return gulp.src([
-			paths.jsSrc + '/../garp/front/styling.js',
-			paths.jsSrc + '/../garp/front/flashmessage.js',
-			paths.jsSrc + '/../garp/front/cookies.js',
-			paths.jsSrc + '/**/*.js',
-		])
+		paths.jsSrc + '/../garp/front/styling.js',
+		paths.jsSrc + '/../garp/front/flashmessage.js',
+		paths.jsSrc + '/../garp/front/cookies.js',
+		paths.jsSrc + '/**/*.js',
+	])
 		.pipe(gulpif(ENV == 'development', sourcemaps.init()))
 		.pipe(concat('main.js'))
 		.pipe(gulpif(ENV != 'development', uglify())).on('error', handleError)
@@ -231,9 +235,9 @@ gulp.task('javascript-cms', function() {
 
 gulp.task('javascript-models', function() {
     return gulp.src([
-			paths.jsSrc + '/../garp/models/*.js',
-			paths.jsSrc + '/../models/*.js',
-		])
+		paths.jsSrc + '/../garp/models/*.js',
+		paths.jsSrc + '/../models/*.js',
+	])
 		.pipe(concat('extended-models.js'))
 		.pipe(uglify()).on('error', handleError)
 		.pipe(gulp.dest(paths.jsBuild))
@@ -246,22 +250,24 @@ gulp.task('bower-concat', function() {
 		return;
 	}
     return gulp.src(mainBowerFiles())
-    .pipe(concat('libs.js'))
-    .pipe(uglify())
-    .pipe(gulp.dest(paths.jsBuild));
+	    .pipe(concat('libs.js'))
+	    .pipe(uglify())
+	    .pipe(gulp.dest(paths.jsBuild))
+	;
 });
 
 gulp.task('jshint', function () {
-    gulp.src(paths.jsSrc + '/**/*.js')
+    return gulp.src(paths.jsSrc + '/**/*.js')
         .pipe(jshint('.jshintrc'))
         .pipe(jshint.reporter('jshint-stylish'));
 });
 
 gulp.task('modernizr', ['sass', 'javascript'], function() {
-  return gulp.src([paths.cssBuild + '/base.css', paths.jsBuild + '/main.js'])
-    .pipe(modernizr('modernizr.js')).on('error', handleError)
-    .pipe(uglify())
-    .pipe(gulp.dest(paths.jsBuild))
+	return gulp.src([paths.cssBuild + '/base.css', paths.jsBuild + '/main.js'])
+		.pipe(modernizr('modernizr.js')).on('error', handleError)
+		.pipe(uglify())
+		.pipe(gulp.dest(paths.jsBuild))
+    ;
 });
 
 gulp.task('images', ['init'], function () {
@@ -273,8 +279,10 @@ gulp.task('images', ['init'], function () {
         .pipe(imagemin({
             progressive: true,
             svgoPlugins: [{removeViewBox: false}]
-        })).on('error', handleError)
-        .pipe(gulp.dest(paths.imgBuild));
+        }))
+        .on('error', handleError)
+        .pipe(gulp.dest(paths.imgBuild))
+    ;
 });
 
 gulp.task('watch', ['default', 'browser-sync'], function() {
@@ -285,7 +293,7 @@ gulp.task('watch', ['default', 'browser-sync'], function() {
     gulp.watch('application/modules/default/**/*.{phtml, php}', browserSync.reload);
 });
 
-gulp.task('default', [
+gulp.task('build', [
 	'init',
 	'sass-ie',
 	'sass-cms',
@@ -293,6 +301,10 @@ gulp.task('default', [
 	'javascript-cms',
 	'javascript-models',
 	'javascript',
-	'images',
+	'images'
+]);
+
+gulp.task('default', [
+	'build',
 	'modernizr'
 ]);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -288,7 +288,7 @@ gulp.task('images', ['init'], function() {
 
 gulp.task('watch', function(cb) {
 	runSequence('default', 'browser-sync', cb);
-	gulp.watch([paths.cssSrc + '/**/*.scss', '!**/cms.scss'], ['sass']);
+	gulp.watch([paths.cssSrc + '/**/*.scss', '!**/cms.scss'], ['sass', 'scss-lint']);
 	gulp.watch(paths.cssSrc + '/**/cms.scss', ['sass-cms']);
 	gulp.watch(paths.jsSrc + '/**/*.js', ['javascript']);
 	gulp.watch(paths.imgSrc + '/**/*.{gif,jpg,svg,png}', ['images']);

--- a/node_modules/run-sequence/.npmignore
+++ b/node_modules/run-sequence/.npmignore
@@ -1,0 +1,10 @@
+.DS_Store
+*.log
+node_modules
+build
+*.node
+components
+*.orig
+.idea
+temp.txt*
+test

--- a/node_modules/run-sequence/.travis.yml
+++ b/node_modules/run-sequence/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.11"

--- a/node_modules/run-sequence/LICENSE
+++ b/node_modules/run-sequence/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2014 [Phil DeJarnett](http://overzealous.com)
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/node_modules/run-sequence/README.md
+++ b/node_modules/run-sequence/README.md
@@ -1,0 +1,107 @@
+# run-sequence
+
+[![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url]
+
+Runs a sequence of gulp tasks in the specified order.  This function is designed to solve the situation where you have defined run-order, but choose not to or cannot use dependencies.
+
+> ### Please Note
+>
+> This is intended to be a temporary solution until [orchestrator](https://github.com/robrich/orchestrator/) is updated to support [non-dependent ordered tasks](https://github.com/robrich/orchestrator/issues/21).
+> 
+> Be aware that this solution is a hack, and may stop working with a future update to orchestrator. 
+
+Each argument to `run-sequence` is run in order.  This works by listening to the `task_stop` and `task_err` events, and keeping track of which tasks have been completed.  You can still run some of the tasks in parallel, by providing an array of task names for one or more of the arguments.
+
+If the final argument is a function, it will be used as a callback after all the functions are either finished or an error has occurred.
+
+## Possible Breaking Change in version 1.0.0
+
+In version 1.0 I've added a check that prevents the same task from showing up within any sequence.  This is to help reduce typo errors, as well as prevent the [silent exit bug when the same task occurred twice in a parallel sequence](https://github.com/OverZealous/run-sequence/issues/13).  The sequence will now fail immediately during the validation stage.
+
+If this breaking change affects you, you'll need to take one of several actions:
+
+1. Remove duplicate tasks if they are a mistake.
+2. Filter unneeded duplicate tasks before passing them to `run-sequence`.
+3. Rewrite your tasks or wrap your tasks within functions that can be called multiple times if for some reason you rely on this functionality.
+4. Continue using `run-sequence` version 0.3.7 if it was working for you.
+
+[I welcome feedback](https://github.com/OverZealous/run-sequence/issues) if this change is a problem for your setup!
+
+## Usage
+
+First, install `run-sequence` as a development dependency:
+
+```shell
+npm install --save-dev run-sequence
+```
+
+Then add use it in your gulpfile, like so:
+
+```js
+var gulp = require('gulp');
+var runSequence = require('run-sequence');
+var clean = require('gulp-clean');
+
+// This will run in this order:
+// * build-clean
+// * build-scripts and build-styles in parallel
+// * build-html
+// * Finally call the callback function
+gulp.task('build', function(callback) {
+  runSequence('build-clean',
+              ['build-scripts', 'build-styles'],
+              'build-html',
+              callback);
+});
+
+// configure build-clean, build-scripts, build-styles, build-html as you
+// wish, but make sure they either return a stream or handle the callback
+// Example:
+
+gulp.task('build-clean', function() {
+    return gulp.src(BUILD_DIRECTORY).pipe(clean());
+//  ^^^^^^
+//   This is the key here, to make sure tasks run asynchronously!
+});
+
+gulp.task('build-scripts', function() {
+    return gulp.src(SCRIPTS_SRC).pipe(...)...
+//  ^^^^^^
+//   This is the key here, to make sure tasks run asynchronously!
+});
+```
+
+### Using within gulp submodules
+
+If you have a complex gulp setup with your tasks split up across different files, you may get the error that `run-sequence` is unable to find your tasks.  In this case, you can configure `run-sequence` to look at the gulp within the submodule, like so:
+
+```js
+// submodule tasks/mygulptask.js
+
+var gulp = require('gulp'), // might be a different instance than the toplevel one
+	// this uses the gulp you provide
+    runSequence = require('run-sequence').use(gulp);
+    
+    // ...and then use normally
+    runSequence('subtask1', 'subtask2');
+```
+
+## Help Support This Project
+
+If you'd like to support this and other OverZealous Creations (Phil DeJarnett) projects, [donate via Gittip][gittip-url]!
+
+[![Support via Gittip][gittip-image]][gittip-url]
+
+## LICENSE
+
+[MIT License](http://en.wikipedia.org/wiki/MIT_License)
+
+
+[npm-url]: https://npmjs.org/package/run-sequence
+[npm-image]: https://badge.fury.io/js/run-sequence.png
+
+[travis-url]: http://travis-ci.org/OverZealous/run-sequence
+[travis-image]: https://secure.travis-ci.org/OverZealous/run-sequence.png?branch=master
+
+[gittip-url]: https://www.gittip.com/OverZealous/
+[gittip-image]: https://raw2.github.com/OverZealous/gittip-badge/0.1.2/dist/gittip.png

--- a/node_modules/run-sequence/index.js
+++ b/node_modules/run-sequence/index.js
@@ -1,0 +1,91 @@
+/*jshint node:true */
+
+"use strict";
+
+var colors = require('chalk');
+
+function verifyTaskSets(gulp, taskSets, skipArrays) {
+	if(taskSets.length === 0) {
+		throw new Error('No tasks were provided to run-sequence');
+	}
+	var foundTasks = {};
+	taskSets.forEach(function(t) {
+		var isTask = typeof t === "string",
+			isArray = !skipArrays && Array.isArray(t);
+		if(!isTask && !isArray) {
+			throw new Error("Task "+t+" is not a valid task string.");
+		}
+		if(isTask && !gulp.hasTask(t)) {
+			throw new Error("Task "+t+" is not configured as a task on gulp.  If this is a submodule, you may need to use require('run-sequence').use(gulp).");
+		}
+		if(skipArrays && isTask) {
+			if(foundTasks[t]) {
+				throw new Error("Task "+t+" is listed more than once. This is probably a typo.");
+			}
+			foundTasks[t] = true;
+		}
+		if(isArray) {
+			if(t.length === 0) {
+				throw new Error("An empty array was provided as a task set");
+			}
+			verifyTaskSets(gulp, t, true, foundTasks);
+		}
+	});
+}
+
+function runSequence(gulp) {
+	// Slice and dice the input to prevent modification of parallel arrays.
+	var taskSets = Array.prototype.slice.call(arguments, 1).map(function(task) {
+			return Array.isArray(task) ? task.slice() : task;
+		}),
+		callBack = typeof taskSets[taskSets.length-1] === 'function' ? taskSets.pop() : false,
+		currentTaskSet,
+
+		finish = function(err) {
+			gulp.removeListener('task_stop', onTaskEnd);
+			gulp.removeListener('task_err', onError);
+			if(callBack) {
+				callBack(err);
+			} else if(err) {
+				console.log(colors.red('Error running task sequence:'), err);
+			}
+		},
+
+		onError = function(err) {
+			finish(err);
+		},
+		onTaskEnd = function(event) {
+			var idx = currentTaskSet.indexOf(event.task);
+			if(idx > -1) {
+				currentTaskSet.splice(idx,1);
+			}
+			if(currentTaskSet.length === 0) {
+				runNextSet();
+			}
+		},
+
+		runNextSet = function() {
+			if(taskSets.length) {
+				var command = taskSets.shift();
+				if(!Array.isArray(command)) {
+					command = [command];
+				}
+				currentTaskSet = command;
+				gulp.start.apply(gulp, command);
+			} else {
+				finish();
+			}
+		};
+
+	verifyTaskSets(gulp, taskSets);
+
+	gulp.on('task_stop', onTaskEnd);
+	gulp.on('task_err', onError);
+
+	runNextSet();
+}
+
+module.exports = runSequence.bind(null, require('gulp'));
+module.exports.use = function(gulp) {
+	return runSequence.bind(null, gulp);
+};

--- a/node_modules/run-sequence/node_modules/chalk/index.js
+++ b/node_modules/run-sequence/node_modules/chalk/index.js
@@ -1,0 +1,95 @@
+'use strict';
+var escapeStringRegexp = require('escape-string-regexp');
+var ansiStyles = require('ansi-styles');
+var stripAnsi = require('strip-ansi');
+var hasAnsi = require('has-ansi');
+var supportsColor = require('supports-color');
+var defineProps = Object.defineProperties;
+var chalk = module.exports;
+
+function build(_styles) {
+	var builder = function builder() {
+		return applyStyle.apply(builder, arguments);
+	};
+	builder._styles = _styles;
+	// __proto__ is used because we must return a function, but there is
+	// no way to create a function with a different prototype.
+	builder.__proto__ = proto;
+	return builder;
+}
+
+var styles = (function () {
+	var ret = {};
+
+	ansiStyles.grey = ansiStyles.gray;
+
+	Object.keys(ansiStyles).forEach(function (key) {
+		ansiStyles[key].closeRe = new RegExp(escapeStringRegexp(ansiStyles[key].close), 'g');
+
+		ret[key] = {
+			get: function () {
+				return build(this._styles.concat(key));
+			}
+		};
+	});
+
+	return ret;
+})();
+
+var proto = defineProps(function chalk() {}, styles);
+
+function applyStyle() {
+	// support varags, but simply cast to string in case there's only one arg
+	var args = arguments;
+	var argsLen = args.length;
+	var str = argsLen !== 0 && String(arguments[0]);
+	if (argsLen > 1) {
+		// don't slice `arguments`, it prevents v8 optimizations
+		for (var a = 1; a < argsLen; a++) {
+			str += ' ' + args[a];
+		}
+	}
+
+	if (!chalk.enabled || !str) {
+		return str;
+	}
+
+	/*jshint validthis: true*/
+	var nestedStyles = this._styles;
+
+	for (var i = 0; i < nestedStyles.length; i++) {
+		var code = ansiStyles[nestedStyles[i]];
+		// Replace any instances already present with a re-opening code
+		// otherwise only the part of the string until said closing code
+		// will be colored, and the rest will simply be 'plain'.
+		str = code.open + str.replace(code.closeRe, code.open) + code.close;
+	}
+
+	return str;
+}
+
+function init() {
+	var ret = {};
+
+	Object.keys(styles).forEach(function (name) {
+		ret[name] = {
+			get: function () {
+				return build([name]);
+			}
+		};
+	});
+
+	return ret;
+}
+
+defineProps(chalk, init());
+
+chalk.styles = ansiStyles;
+chalk.hasColor = hasAnsi;
+chalk.stripColor = stripAnsi;
+chalk.supportsColor = supportsColor;
+
+// detect mode if not set manually
+if (chalk.enabled === undefined) {
+	chalk.enabled = chalk.supportsColor;
+}

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/.bin/has-ansi
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/.bin/has-ansi
@@ -1,0 +1,1 @@
+../has-ansi/cli.js

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/.bin/strip-ansi
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/.bin/strip-ansi
@@ -1,0 +1,1 @@
+../strip-ansi/cli.js

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/.bin/supports-color
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/.bin/supports-color
@@ -1,0 +1,1 @@
+../supports-color/cli.js

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/ansi-styles/index.js
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/ansi-styles/index.js
@@ -1,0 +1,40 @@
+'use strict';
+var styles = module.exports;
+
+var codes = {
+	reset: [0, 0],
+
+	bold: [1, 22], // 21 isn't widely supported and 22 does the same thing
+	dim: [2, 22],
+	italic: [3, 23],
+	underline: [4, 24],
+	inverse: [7, 27],
+	hidden: [8, 28],
+	strikethrough: [9, 29],
+
+	black: [30, 39],
+	red: [31, 39],
+	green: [32, 39],
+	yellow: [33, 39],
+	blue: [34, 39],
+	magenta: [35, 39],
+	cyan: [36, 39],
+	white: [37, 39],
+	gray: [90, 39],
+
+	bgBlack: [40, 49],
+	bgRed: [41, 49],
+	bgGreen: [42, 49],
+	bgYellow: [43, 49],
+	bgBlue: [44, 49],
+	bgMagenta: [45, 49],
+	bgCyan: [46, 49],
+	bgWhite: [47, 49]
+};
+
+Object.keys(codes).forEach(function (key) {
+	var val = codes[key];
+	var style = styles[key] = {};
+	style.open = '\u001b[' + val[0] + 'm';
+	style.close = '\u001b[' + val[1] + 'm';
+});

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/ansi-styles/package.json
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/ansi-styles/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "ansi-styles",
+  "version": "1.1.0",
+  "description": "ANSI escape codes for styling strings in the terminal",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sindresorhus/ansi-styles"
+  },
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "http://sindresorhus.com"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "files": [
+    "index.js"
+  ],
+  "keywords": [
+    "ansi",
+    "styles",
+    "color",
+    "colour",
+    "colors",
+    "terminal",
+    "console",
+    "cli",
+    "string",
+    "tty",
+    "escape",
+    "formatting",
+    "rgb",
+    "256",
+    "shell",
+    "xterm",
+    "log",
+    "logging",
+    "command-line",
+    "text"
+  ],
+  "devDependencies": {
+    "mocha": "*"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/ansi-styles/issues"
+  },
+  "homepage": "https://github.com/sindresorhus/ansi-styles",
+  "_id": "ansi-styles@1.1.0",
+  "_shasum": "eaecbf66cd706882760b2f4691582b8f55d7a7de",
+  "_from": "ansi-styles@>=1.1.0 <2.0.0",
+  "_npmVersion": "1.4.9",
+  "_npmUser": {
+    "name": "sindresorhus",
+    "email": "sindresorhus@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "dist": {
+    "shasum": "eaecbf66cd706882760b2f4691582b8f55d7a7de",
+    "tarball": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+  "readme": "ERROR: No README data found!"
+}

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/ansi-styles/readme.md
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/ansi-styles/readme.md
@@ -1,0 +1,70 @@
+# ansi-styles [![Build Status](https://travis-ci.org/sindresorhus/ansi-styles.svg?branch=master)](https://travis-ci.org/sindresorhus/ansi-styles)
+
+> [ANSI escape codes](http://en.wikipedia.org/wiki/ANSI_escape_code#Colors_and_Styles) for styling strings in the terminal
+
+You probably want the higher-level [chalk](https://github.com/sindresorhus/chalk) module for styling your strings.
+
+![screenshot](screenshot.png)
+
+
+## Install
+
+```sh
+$ npm install --save ansi-styles
+```
+
+
+## Usage
+
+```js
+var ansi = require('ansi-styles');
+
+console.log(ansi.green.open + 'Hello world!' + ansi.green.close);
+```
+
+
+## API
+
+Each style has an `open` and `close` property.
+
+
+## Styles
+
+### General
+
+- `reset`
+- `bold`
+- `dim`
+- `italic` *(not widely supported)*
+- `underline`
+- `inverse`
+- `hidden`
+- `strikethrough` *(not widely supported)*
+
+### Text colors
+
+- `black`
+- `red`
+- `green`
+- `yellow`
+- `blue`
+- `magenta`
+- `cyan`
+- `white`
+- `gray`
+
+### Background colors
+
+- `bgBlack`
+- `bgRed`
+- `bgGreen`
+- `bgYellow`
+- `bgBlue`
+- `bgMagenta`
+- `bgCyan`
+- `bgWhite`
+
+
+## License
+
+MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/escape-string-regexp/index.js
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/escape-string-regexp/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var matchOperatorsRe = /[|\\{}()[\]^$+*?.]/g;
+
+module.exports = function (str) {
+	if (typeof str !== 'string') {
+		throw new TypeError('Expected a string');
+	}
+
+	return str.replace(matchOperatorsRe,  '\\$&');
+};

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/escape-string-regexp/package.json
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/escape-string-regexp/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "escape-string-regexp",
+  "version": "1.0.2",
+  "description": "Escape RegExp special characters",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sindresorhus/escape-string-regexp"
+  },
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "http://sindresorhus.com"
+  },
+  "engines": {
+    "node": ">=0.8.0"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "files": [
+    "index.js"
+  ],
+  "keywords": [
+    "regex",
+    "regexp",
+    "re",
+    "regular",
+    "expression",
+    "escape",
+    "string",
+    "str",
+    "special",
+    "characters"
+  ],
+  "devDependencies": {
+    "mocha": "*"
+  },
+  "gitHead": "0587ee0ee03ea3fcbfa3c15cf67b47f214e20987",
+  "bugs": {
+    "url": "https://github.com/sindresorhus/escape-string-regexp/issues"
+  },
+  "homepage": "https://github.com/sindresorhus/escape-string-regexp",
+  "_id": "escape-string-regexp@1.0.2",
+  "_shasum": "4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1",
+  "_from": "escape-string-regexp@>=1.0.0 <2.0.0",
+  "_npmVersion": "1.4.23",
+  "_npmUser": {
+    "name": "jbnicolai",
+    "email": "jappelman@xebia.com"
+  },
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    },
+    {
+      "name": "jbnicolai",
+      "email": "jappelman@xebia.com"
+    }
+  ],
+  "dist": {
+    "shasum": "4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1",
+    "tarball": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+  "readme": "ERROR: No README data found!"
+}

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/escape-string-regexp/readme.md
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/escape-string-regexp/readme.md
@@ -1,0 +1,27 @@
+# escape-string-regexp [![Build Status](https://travis-ci.org/sindresorhus/escape-string-regexp.svg?branch=master)](https://travis-ci.org/sindresorhus/escape-string-regexp)
+
+> Escape RegExp special characters
+
+
+## Install
+
+```sh
+$ npm install --save escape-string-regexp
+```
+
+
+## Usage
+
+```js
+var escapeStringRegexp = require('escape-string-regexp');
+
+var escapedString = escapeStringRegexp('how much $ for a unicorn?');
+//=> how much \$ for a unicorn\?
+
+new RegExp(escapedString);
+```
+
+
+## License
+
+MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/has-ansi/cli.js
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/has-ansi/cli.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+'use strict';
+var pkg = require('./package.json');
+var hasAnsi = require('./');
+var input = process.argv[2];
+
+function stdin(cb) {
+	var ret = '';
+	process.stdin.setEncoding('utf8');
+	process.stdin.on('data', function (data) {
+		ret += data;
+	});
+	process.stdin.on('end', function () {
+		cb(ret);
+	});
+}
+
+function help() {
+	console.log([
+		pkg.description,
+		'',
+		'Usage',
+		'  $ has-ansi <string>',
+		'  $ echo <string> | has-ansi',
+		'',
+		'Exits with code 0 if input has ANSI escape codes and 1 if not'
+	].join('\n'));
+}
+
+function init(data) {
+	process.exit(hasAnsi(data) ? 0 : 1);
+}
+
+if (process.argv.indexOf('--help') !== -1) {
+	help();
+	return;
+}
+
+if (process.argv.indexOf('--version') !== -1) {
+	console.log(pkg.version);
+	return;
+}
+
+if (process.stdin.isTTY) {
+	if (!input) {
+		help();
+		return;
+	}
+
+	init(input);
+} else {
+	stdin(init);
+}

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/has-ansi/index.js
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/has-ansi/index.js
@@ -1,0 +1,4 @@
+'use strict';
+var ansiRegex = require('ansi-regex');
+var re = new RegExp(ansiRegex().source); // remove the `g` flag
+module.exports = re.test.bind(re);

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/has-ansi/node_modules/ansi-regex/index.js
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/has-ansi/node_modules/ansi-regex/index.js
@@ -1,0 +1,4 @@
+'use strict';
+module.exports = function () {
+	return /\u001b\[(?:[0-9]{1,3}(?:;[0-9]{1,3})*)?[m|K]/g;
+};

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/has-ansi/node_modules/ansi-regex/package.json
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/has-ansi/node_modules/ansi-regex/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "ansi-regex",
+  "version": "0.2.1",
+  "description": "Regular expression for matching ANSI escape codes",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sindresorhus/ansi-regex"
+  },
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "http://sindresorhus.com"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "files": [
+    "index.js"
+  ],
+  "keywords": [
+    "ansi",
+    "styles",
+    "color",
+    "colour",
+    "colors",
+    "terminal",
+    "console",
+    "cli",
+    "string",
+    "tty",
+    "escape",
+    "formatting",
+    "rgb",
+    "256",
+    "shell",
+    "xterm",
+    "command-line",
+    "text",
+    "regex",
+    "regexp",
+    "re",
+    "match",
+    "test",
+    "find",
+    "pattern"
+  ],
+  "devDependencies": {
+    "mocha": "*"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/ansi-regex/issues"
+  },
+  "homepage": "https://github.com/sindresorhus/ansi-regex",
+  "_id": "ansi-regex@0.2.1",
+  "_shasum": "0d8e946967a3d8143f93e24e298525fc1b2235f9",
+  "_from": "ansi-regex@>=0.2.1 <0.3.0",
+  "_npmVersion": "1.4.9",
+  "_npmUser": {
+    "name": "sindresorhus",
+    "email": "sindresorhus@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "dist": {
+    "shasum": "0d8e946967a3d8143f93e24e298525fc1b2235f9",
+    "tarball": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+  "readme": "ERROR: No README data found!"
+}

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/has-ansi/node_modules/ansi-regex/readme.md
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/has-ansi/node_modules/ansi-regex/readme.md
@@ -1,0 +1,33 @@
+# ansi-regex [![Build Status](https://travis-ci.org/sindresorhus/ansi-regex.svg?branch=master)](https://travis-ci.org/sindresorhus/ansi-regex)
+
+> Regular expression for matching [ANSI escape codes](http://en.wikipedia.org/wiki/ANSI_escape_code)
+
+
+## Install
+
+```sh
+$ npm install --save ansi-regex
+```
+
+
+## Usage
+
+```js
+var ansiRegex = require('ansi-regex');
+
+ansiRegex().test('\u001b[4mcake\u001b[0m');
+//=> true
+
+ansiRegex().test('cake');
+//=> false
+
+'\u001b[4mcake\u001b[0m'.match(ansiRegex());
+//=> ['\u001b[4m', '\u001b[0m']
+```
+
+*It's a function so you can create multiple instances. Regexes with the global flag will have the `.lastIndex` property changed for each call to methods on the instance. Therefore reusing the instance with multiple calls will not work as expected for `.test()`.*
+
+
+## License
+
+MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/has-ansi/package.json
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/has-ansi/package.json
@@ -1,0 +1,85 @@
+{
+  "name": "has-ansi",
+  "version": "0.1.0",
+  "description": "Check if a string has ANSI escape codes",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sindresorhus/has-ansi"
+  },
+  "bin": {
+    "has-ansi": "cli.js"
+  },
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "http://sindresorhus.com"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "files": [
+    "index.js",
+    "cli.js"
+  ],
+  "keywords": [
+    "cli",
+    "bin",
+    "ansi",
+    "styles",
+    "color",
+    "colour",
+    "colors",
+    "terminal",
+    "console",
+    "string",
+    "tty",
+    "escape",
+    "shell",
+    "xterm",
+    "command-line",
+    "text",
+    "regex",
+    "regexp",
+    "re",
+    "match",
+    "test",
+    "find",
+    "pattern",
+    "has"
+  ],
+  "dependencies": {
+    "ansi-regex": "^0.2.0"
+  },
+  "devDependencies": {
+    "mocha": "*"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/has-ansi/issues"
+  },
+  "homepage": "https://github.com/sindresorhus/has-ansi",
+  "_id": "has-ansi@0.1.0",
+  "_shasum": "84f265aae8c0e6a88a12d7022894b7568894c62e",
+  "_from": "has-ansi@>=0.1.0 <0.2.0",
+  "_npmVersion": "1.4.9",
+  "_npmUser": {
+    "name": "sindresorhus",
+    "email": "sindresorhus@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "dist": {
+    "shasum": "84f265aae8c0e6a88a12d7022894b7568894c62e",
+    "tarball": "http://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+  "readme": "ERROR: No README data found!"
+}

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/has-ansi/readme.md
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/has-ansi/readme.md
@@ -1,0 +1,45 @@
+# has-ansi [![Build Status](https://travis-ci.org/sindresorhus/has-ansi.svg?branch=master)](https://travis-ci.org/sindresorhus/has-ansi)
+
+> Check if a string has [ANSI escape codes](http://en.wikipedia.org/wiki/ANSI_escape_code)
+
+
+## Install
+
+```sh
+$ npm install --save has-ansi
+```
+
+
+## Usage
+
+```js
+var hasAnsi = require('has-ansi');
+
+hasAnsi('\u001b[4mcake\u001b[0m');
+//=> true
+
+hasAnsi('cake');
+//=> false
+```
+
+
+## CLI
+
+```sh
+$ npm install --global has-ansi
+```
+
+```
+$ has-ansi --help
+
+Usage
+  $ has-ansi <string>
+  $ echo <string> | has-ansi
+
+Exits with code 0 if input has ANSI escape codes and 1 if not
+```
+
+
+## License
+
+MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/strip-ansi/cli.js
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/strip-ansi/cli.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+'use strict';
+var fs = require('fs');
+var pkg = require('./package.json');
+var strip = require('./');
+var input = process.argv[2];
+
+function help() {
+	console.log([
+		pkg.description,
+		'',
+		'Usage',
+		'  $ strip-ansi <input-file> > <output-file>',
+		'  $ cat <input-file> | strip-ansi > <output-file>',
+		'',
+		'Example',
+		'  $ strip-ansi unicorn.txt > unicorn-stripped.txt'
+	].join('\n'));
+}
+
+if (process.argv.indexOf('--help') !== -1) {
+	help();
+	return;
+}
+
+if (process.argv.indexOf('--version') !== -1) {
+	console.log(pkg.version);
+	return;
+}
+
+if (input) {
+	process.stdout.write(strip(fs.readFileSync(input, 'utf8')));
+	return;
+}
+
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', function (data) {
+	process.stdout.write(strip(data));
+});

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/strip-ansi/index.js
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/strip-ansi/index.js
@@ -1,0 +1,6 @@
+'use strict';
+var ansiRegex = require('ansi-regex')();
+
+module.exports = function (str) {
+	return typeof str === 'string' ? str.replace(ansiRegex, '') : str;
+};

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/strip-ansi/node_modules/ansi-regex/index.js
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/strip-ansi/node_modules/ansi-regex/index.js
@@ -1,0 +1,4 @@
+'use strict';
+module.exports = function () {
+	return /\u001b\[(?:[0-9]{1,3}(?:;[0-9]{1,3})*)?[m|K]/g;
+};

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/strip-ansi/node_modules/ansi-regex/package.json
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/strip-ansi/node_modules/ansi-regex/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "ansi-regex",
+  "version": "0.2.1",
+  "description": "Regular expression for matching ANSI escape codes",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sindresorhus/ansi-regex"
+  },
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "http://sindresorhus.com"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "files": [
+    "index.js"
+  ],
+  "keywords": [
+    "ansi",
+    "styles",
+    "color",
+    "colour",
+    "colors",
+    "terminal",
+    "console",
+    "cli",
+    "string",
+    "tty",
+    "escape",
+    "formatting",
+    "rgb",
+    "256",
+    "shell",
+    "xterm",
+    "command-line",
+    "text",
+    "regex",
+    "regexp",
+    "re",
+    "match",
+    "test",
+    "find",
+    "pattern"
+  ],
+  "devDependencies": {
+    "mocha": "*"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/ansi-regex/issues"
+  },
+  "homepage": "https://github.com/sindresorhus/ansi-regex",
+  "_id": "ansi-regex@0.2.1",
+  "_shasum": "0d8e946967a3d8143f93e24e298525fc1b2235f9",
+  "_from": "ansi-regex@>=0.2.1 <0.3.0",
+  "_npmVersion": "1.4.9",
+  "_npmUser": {
+    "name": "sindresorhus",
+    "email": "sindresorhus@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "dist": {
+    "shasum": "0d8e946967a3d8143f93e24e298525fc1b2235f9",
+    "tarball": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+  "readme": "ERROR: No README data found!"
+}

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/strip-ansi/node_modules/ansi-regex/readme.md
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/strip-ansi/node_modules/ansi-regex/readme.md
@@ -1,0 +1,33 @@
+# ansi-regex [![Build Status](https://travis-ci.org/sindresorhus/ansi-regex.svg?branch=master)](https://travis-ci.org/sindresorhus/ansi-regex)
+
+> Regular expression for matching [ANSI escape codes](http://en.wikipedia.org/wiki/ANSI_escape_code)
+
+
+## Install
+
+```sh
+$ npm install --save ansi-regex
+```
+
+
+## Usage
+
+```js
+var ansiRegex = require('ansi-regex');
+
+ansiRegex().test('\u001b[4mcake\u001b[0m');
+//=> true
+
+ansiRegex().test('cake');
+//=> false
+
+'\u001b[4mcake\u001b[0m'.match(ansiRegex());
+//=> ['\u001b[4m', '\u001b[0m']
+```
+
+*It's a function so you can create multiple instances. Regexes with the global flag will have the `.lastIndex` property changed for each call to methods on the instance. Therefore reusing the instance with multiple calls will not work as expected for `.test()`.*
+
+
+## License
+
+MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/strip-ansi/package.json
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/strip-ansi/package.json
@@ -1,0 +1,84 @@
+{
+  "name": "strip-ansi",
+  "version": "0.3.0",
+  "description": "Strip ANSI escape codes",
+  "license": "MIT",
+  "bin": {
+    "strip-ansi": "cli.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sindresorhus/strip-ansi"
+  },
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "http://sindresorhus.com"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "files": [
+    "index.js",
+    "cli.js"
+  ],
+  "keywords": [
+    "strip",
+    "trim",
+    "remove",
+    "ansi",
+    "styles",
+    "color",
+    "colour",
+    "colors",
+    "terminal",
+    "console",
+    "cli",
+    "string",
+    "tty",
+    "escape",
+    "formatting",
+    "rgb",
+    "256",
+    "shell",
+    "xterm",
+    "log",
+    "logging",
+    "command-line",
+    "text"
+  ],
+  "dependencies": {
+    "ansi-regex": "^0.2.1"
+  },
+  "devDependencies": {
+    "mocha": "*"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/strip-ansi/issues"
+  },
+  "homepage": "https://github.com/sindresorhus/strip-ansi",
+  "_id": "strip-ansi@0.3.0",
+  "_shasum": "25f48ea22ca79187f3174a4db8759347bb126220",
+  "_from": "strip-ansi@>=0.3.0 <0.4.0",
+  "_npmVersion": "1.4.9",
+  "_npmUser": {
+    "name": "sindresorhus",
+    "email": "sindresorhus@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "dist": {
+    "shasum": "25f48ea22ca79187f3174a4db8759347bb126220",
+    "tarball": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+  "readme": "ERROR: No README data found!"
+}

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/strip-ansi/readme.md
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/strip-ansi/readme.md
@@ -1,0 +1,43 @@
+# strip-ansi [![Build Status](https://travis-ci.org/sindresorhus/strip-ansi.svg?branch=master)](https://travis-ci.org/sindresorhus/strip-ansi)
+
+> Strip [ANSI escape codes](http://en.wikipedia.org/wiki/ANSI_escape_code)
+
+
+## Install
+
+```sh
+$ npm install --save strip-ansi
+```
+
+
+## Usage
+
+```js
+var stripAnsi = require('strip-ansi');
+
+stripAnsi('\x1b[4mcake\x1b[0m');
+//=> 'cake'
+```
+
+
+## CLI
+
+```sh
+$ npm install --global strip-ansi
+```
+
+```sh
+$ strip-ansi --help
+
+Usage
+  $ strip-ansi <input-file> > <output-file>
+  $ cat <input-file> | strip-ansi > <output-file>
+
+Example
+  $ strip-ansi unicorn.txt > unicorn-stripped.txt
+```
+
+
+## License
+
+MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/supports-color/cli.js
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/supports-color/cli.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+'use strict';
+var pkg = require('./package.json');
+var supportsColor = require('./');
+var input = process.argv[2];
+
+function help() {
+	console.log([
+		pkg.description,
+		'',
+		'Usage',
+		'  $ supports-color',
+		'',
+		'Exits with code 0 if color is supported and 1 if not'
+	].join('\n'));
+}
+
+if (!input || process.argv.indexOf('--help') !== -1) {
+	help();
+	return;
+}
+
+if (process.argv.indexOf('--version') !== -1) {
+	console.log(pkg.version);
+	return;
+}
+
+process.exit(supportsColor ? 0 : 1);

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/supports-color/index.js
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/supports-color/index.js
@@ -1,0 +1,32 @@
+'use strict';
+module.exports = (function () {
+	if (process.argv.indexOf('--no-color') !== -1) {
+		return false;
+	}
+
+	if (process.argv.indexOf('--color') !== -1) {
+		return true;
+	}
+
+	if (process.stdout && !process.stdout.isTTY) {
+		return false;
+	}
+
+	if (process.platform === 'win32') {
+		return true;
+	}
+
+	if ('COLORTERM' in process.env) {
+		return true;
+	}
+
+	if (process.env.TERM === 'dumb') {
+		return false;
+	}
+
+	if (/^screen|^xterm|^vt100|color|ansi|cygwin|linux/i.test(process.env.TERM)) {
+		return true;
+	}
+
+	return false;
+})();

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/supports-color/package.json
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/supports-color/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "supports-color",
+  "version": "0.2.0",
+  "description": "Detect whether a terminal supports color",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sindresorhus/supports-color"
+  },
+  "bin": {
+    "supports-color": "cli.js"
+  },
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "http://sindresorhus.com"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "files": [
+    "index.js",
+    "cli.js"
+  ],
+  "keywords": [
+    "cli",
+    "bin",
+    "color",
+    "colour",
+    "colors",
+    "terminal",
+    "console",
+    "cli",
+    "ansi",
+    "styles",
+    "tty",
+    "rgb",
+    "256",
+    "shell",
+    "xterm",
+    "command-line",
+    "support",
+    "supports",
+    "capability",
+    "detect"
+  ],
+  "devDependencies": {
+    "mocha": "*"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/supports-color/issues"
+  },
+  "homepage": "https://github.com/sindresorhus/supports-color",
+  "_id": "supports-color@0.2.0",
+  "_shasum": "d92de2694eb3f67323973d7ae3d8b55b4c22190a",
+  "_from": "supports-color@>=0.2.0 <0.3.0",
+  "_npmVersion": "1.4.9",
+  "_npmUser": {
+    "name": "sindresorhus",
+    "email": "sindresorhus@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "dist": {
+    "shasum": "d92de2694eb3f67323973d7ae3d8b55b4c22190a",
+    "tarball": "http://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+  "readme": "ERROR: No README data found!"
+}

--- a/node_modules/run-sequence/node_modules/chalk/node_modules/supports-color/readme.md
+++ b/node_modules/run-sequence/node_modules/chalk/node_modules/supports-color/readme.md
@@ -1,0 +1,44 @@
+# supports-color [![Build Status](https://travis-ci.org/sindresorhus/supports-color.svg?branch=master)](https://travis-ci.org/sindresorhus/supports-color)
+
+> Detect whether a terminal supports color
+
+
+## Install
+
+```sh
+$ npm install --save supports-color
+```
+
+
+## Usage
+
+```js
+var supportsColor = require('supports-color');
+
+if (supportsColor) {
+	console.log('Terminal supports color');
+}
+```
+
+It obeys the `--color` and `--no-color` CLI flags.
+
+
+## CLI
+
+```sh
+$ npm install --global supports-color
+```
+
+```sh
+$ supports-color --help
+
+Usage
+  $ supports-color
+
+# Exits with code 0 if color is supported and 1 if not
+```
+
+
+## License
+
+MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/node_modules/run-sequence/node_modules/chalk/package.json
+++ b/node_modules/run-sequence/node_modules/chalk/package.json
@@ -1,0 +1,82 @@
+{
+  "name": "chalk",
+  "version": "0.5.1",
+  "description": "Terminal string styling done right. Created because the `colors` module does some really horrible things.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sindresorhus/chalk"
+  },
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    },
+    {
+      "name": "jbnicolai",
+      "email": "jappelman@xebia.com"
+    }
+  ],
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "scripts": {
+    "test": "mocha",
+    "bench": "matcha benchmark.js"
+  },
+  "files": [
+    "index.js"
+  ],
+  "keywords": [
+    "color",
+    "colour",
+    "colors",
+    "terminal",
+    "console",
+    "cli",
+    "string",
+    "ansi",
+    "styles",
+    "tty",
+    "formatting",
+    "rgb",
+    "256",
+    "shell",
+    "xterm",
+    "log",
+    "logging",
+    "command-line",
+    "text"
+  ],
+  "dependencies": {
+    "ansi-styles": "^1.1.0",
+    "escape-string-regexp": "^1.0.0",
+    "has-ansi": "^0.1.0",
+    "strip-ansi": "^0.3.0",
+    "supports-color": "^0.2.0"
+  },
+  "devDependencies": {
+    "matcha": "^0.5.0",
+    "mocha": "*"
+  },
+  "gitHead": "994758f01293f1fdcf63282e9917cb9f2cfbdaac",
+  "bugs": {
+    "url": "https://github.com/sindresorhus/chalk/issues"
+  },
+  "homepage": "https://github.com/sindresorhus/chalk",
+  "_id": "chalk@0.5.1",
+  "_shasum": "663b3a648b68b55d04690d49167aa837858f2174",
+  "_from": "chalk@*",
+  "_npmVersion": "1.4.14",
+  "_npmUser": {
+    "name": "jbnicolai",
+    "email": "jappelman@xebia.com"
+  },
+  "dist": {
+    "shasum": "663b3a648b68b55d04690d49167aa837858f2174",
+    "tarball": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+  "readme": "ERROR: No README data found!"
+}

--- a/node_modules/run-sequence/node_modules/chalk/readme.md
+++ b/node_modules/run-sequence/node_modules/chalk/readme.md
@@ -1,0 +1,175 @@
+# <img width="300" src="https://cdn.rawgit.com/sindresorhus/chalk/77ae94f63ab1ac61389b190e5a59866569d1a376/logo.svg" alt="chalk">
+
+> Terminal string styling done right
+
+[![Build Status](https://travis-ci.org/sindresorhus/chalk.svg?branch=master)](https://travis-ci.org/sindresorhus/chalk)
+![](http://img.shields.io/badge/unicorn-approved-ff69b4.svg)
+
+[colors.js](https://github.com/Marak/colors.js) is currently the most popular string styling module, but it has serious deficiencies like extending String.prototype which causes all kinds of [problems](https://github.com/yeoman/yo/issues/68). Although there are other ones, they either do too much or not enough.
+
+**Chalk is a clean and focused alternative.**
+
+![screenshot](https://github.com/sindresorhus/ansi-styles/raw/master/screenshot.png)
+
+
+## Why
+
+- Highly performant
+- Doesn't extend String.prototype
+- Expressive API
+- Ability to nest styles
+- Clean and focused
+- Auto-detects color support
+- Actively maintained
+- [Used by 1000+ modules](https://npmjs.org/browse/depended/chalk)
+
+
+## Install
+
+```sh
+$ npm install --save chalk
+```
+
+
+## Usage
+
+Chalk comes with an easy to use composable API where you just chain and nest the styles you want.
+
+```js
+var chalk = require('chalk');
+
+// style a string
+console.log(  chalk.blue('Hello world!')  );
+
+// combine styled and normal strings
+console.log(  chalk.blue('Hello'), 'World' + chalk.red('!')  );
+
+// compose multiple styles using the chainable API
+console.log(  chalk.blue.bgRed.bold('Hello world!')  );
+
+// pass in multiple arguments
+console.log(  chalk.blue('Hello', 'World!', 'Foo', 'bar', 'biz', 'baz')  );
+
+// nest styles
+console.log(  chalk.red('Hello', chalk.underline.bgBlue('world') + '!')  );
+
+// nest styles of the same type even (color, underline, background)
+console.log(  chalk.green('I am a green line ' + chalk.blue('with a blue substring') + ' that becomes green again!')  );
+```
+
+Easily define your own themes.
+
+```js
+var chalk = require('chalk');
+var error = chalk.bold.red;
+console.log(error('Error!'));
+```
+
+Take advantage of console.log [string substitution](http://nodejs.org/docs/latest/api/console.html#console_console_log_data).
+
+```js
+var name = 'Sindre';
+console.log(chalk.green('Hello %s'), name);
+//=> Hello Sindre
+```
+
+
+## API
+
+### chalk.`<style>[.<style>...](string, [string...])`
+
+Example: `chalk.red.bold.underline('Hello', 'world');`
+
+Chain [styles](#styles) and call the last one as a method with a string argument. Order doesn't matter.
+
+Multiple arguments will be separated by space.
+
+### chalk.enabled
+
+Color support is automatically detected, but you can override it.
+
+### chalk.supportsColor
+
+Detect whether the terminal [supports color](https://github.com/sindresorhus/supports-color).
+
+Can be overridden by the user with the flags `--color` and `--no-color`.
+
+Used internally and handled for you, but exposed for convenience.
+
+### chalk.styles
+
+Exposes the styles as [ANSI escape codes](https://github.com/sindresorhus/ansi-styles).
+
+Generally not useful, but you might need just the `.open` or `.close` escape code if you're mixing externally styled strings with yours.
+
+```js
+var chalk = require('chalk');
+
+console.log(chalk.styles.red);
+//=> {open: '\u001b[31m', close: '\u001b[39m'}
+
+console.log(chalk.styles.red.open + 'Hello' + chalk.styles.red.close);
+```
+
+### chalk.hasColor(string)
+
+Check whether a string [has color](https://github.com/sindresorhus/has-ansi).
+
+### chalk.stripColor(string)
+
+[Strip color](https://github.com/sindresorhus/strip-ansi) from a string.
+
+Can be useful in combination with `.supportsColor` to strip color on externally styled text when it's not supported.
+
+Example:
+
+```js
+var chalk = require('chalk');
+var styledString = getText();
+
+if (!chalk.supportsColor) {
+	styledString = chalk.stripColor(styledString);
+}
+```
+
+
+## Styles
+
+### General
+
+- `reset`
+- `bold`
+- `dim`
+- `italic` *(not widely supported)*
+- `underline`
+- `inverse`
+- `hidden`
+- `strikethrough` *(not widely supported)*
+
+### Text colors
+
+- `black`
+- `red`
+- `green`
+- `yellow`
+- `blue`
+- `magenta`
+- `cyan`
+- `white`
+- `gray`
+
+### Background colors
+
+- `bgBlack`
+- `bgRed`
+- `bgGreen`
+- `bgYellow`
+- `bgBlue`
+- `bgMagenta`
+- `bgCyan`
+- `bgWhite`
+
+
+## License
+
+MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/node_modules/run-sequence/package.json
+++ b/node_modules/run-sequence/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "run-sequence",
+  "description": "Run a series of dependent gulp tasks in order",
+  "version": "1.0.2",
+  "homepage": "https://github.com/OverZealous/run-sequence",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/OverZealous/run-sequence.git"
+  },
+  "bugs": {
+    "url": "https://github.com/OverZealous/run-sequence/issues"
+  },
+  "author": {
+    "name": "Phil DeJarnett",
+    "url": "http://overzealous.com/"
+  },
+  "main": "./index.js",
+  "keywords": [
+    "gulpfriendly",
+    "pipe",
+    "sequence",
+    "gulp",
+    "orchestrator"
+  ],
+  "dependencies": {
+    "chalk": "*"
+  },
+  "devDependencies": {
+    "gulp": "*",
+    "mocha": "*",
+    "should": "*"
+  },
+  "scripts": {
+    "test": "mocha --reporter spec"
+  },
+  "engines": {
+    "node": ">= 0.8.0"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://github.com/OverZealous/run-sequence/raw/master/LICENSE"
+    }
+  ],
+  "gitHead": "521b46c0a2677e765c801c1614ad5b9a243b6318",
+  "_id": "run-sequence@1.0.2",
+  "_shasum": "84175773c38627e9bbd20c4969bf73ef42b6b5d5",
+  "_from": "run-sequence@*",
+  "_npmVersion": "2.1.8",
+  "_nodeVersion": "0.10.33",
+  "_npmUser": {
+    "name": "overzealous",
+    "email": "phil@overzealous.com"
+  },
+  "maintainers": [
+    {
+      "name": "overzealous",
+      "email": "phil@overzealous.com"
+    }
+  ],
+  "dist": {
+    "shasum": "84175773c38627e9bbd20c4969bf73ef42b6b5d5",
+    "tarball": "http://registry.npmjs.org/run-sequence/-/run-sequence-1.0.2.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.0.2.tgz"
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gulp-util": "^3.0.2",
     "jshint-stylish": "^1.0.0",
     "main-bower-files": "^2.5.0",
+    "run-sequence": "^1.0.2",
     "yargs": "^1.3.3"
   }
 }


### PR DESCRIPTION
* Added `runSequence` to make sure Modernizr runs in sequence
* Made sure the output on the command line is more readable and sequenced
* Converted all spaces to tabs, fixed indenting and made the code more consistent
* Made sure all the `gulp.src` tasks `return`, so Gulp knows when it's done (async)
* Turned off `scss-lint` as `sass` dependency. Currently it takes up to 3 – 5 times (!) as long to compile only `base.scss`, so don't run it while live compiling (`watch`).